### PR TITLE
Fix TypeError in play_audio.py due to unsupported type hint

### DIFF
--- a/play_audio.py
+++ b/play_audio.py
@@ -8,6 +8,7 @@ import logging
 import hashlib
 import subprocess
 import re
+from typing import Union
 
 # Define working directories and file paths / Määrake töökaustad ja failiteed
 WORKING_DIR = os.path.expanduser("~/Radio")
@@ -114,7 +115,7 @@ def is_time_between(begin_time, end_time, check_time=None):
     else:  # When the time period spans midnight / Kui ajavahemik ületab südaöö
         return check_time >= begin_time or check_time <= end_time
 
-def detect_raspberry_pi_audio_device() -> str | None:
+def detect_raspberry_pi_audio_device() -> Union[str, None]:
     logging.info("Attempting to auto-detect Raspberry Pi audio device...")
     try:
         # Try parsing 'aplay -l' output


### PR DESCRIPTION
The script was using `str | None` for type hinting, which is a feature introduced in Python 3.10. This caused a `TypeError` when running on older Python versions.

This commit changes the type hint to `typing.Union[str, None]` and adds the necessary import to make the script compatible with older Python versions.