### PR TITLE
feat: Implement configurable background music folder

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,11 @@ time_after_closing = 15
 # Interval in minutes to check the configuration file for changes
 config_check_interval = 120
 
+# Specify the folder for background music.
+# If commented out or left empty, the script will look for a 'bgmusic' folder
+# in the working directory (e.g., ~/Radio/bgmusic).
+# background_music_folder = "/path/to/your/music"
+
 # Weekly schedule for opening and closing times
 [weekly_schedule.monday]
 # This is example time what differs from default times.

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,29 @@ In this example, you might use hw:2,0 for the headphones.
 
 ## Configuration
 
-Make sure you have a config.toml file in the same directory as your script. An example configuration file (config.toml) is provided in the repository.
+Make sure you have a `config.toml` file in the `~/Radio/` directory (or your chosen `WORKING_DIR`). An example configuration file (`config.toml`) is provided in the repository.
+
+### Background Music
+
+There are two ways to configure the background music:
+
+1.  **Default Folder:**
+    *   Create a folder named `bgmusic` inside your working directory (e.g., `~/Radio/bgmusic/`).
+    *   Place your audio files (e.g., `.mp3`, `.wav`) into this `bgmusic` folder.
+    *   If the `background_music_folder` option in `config.toml` is commented out or empty, the script will automatically use this `bgmusic` folder.
+
+2.  **Custom Folder via `config.toml`:**
+    *   Open your `config.toml` file.
+    *   Find or add the `background_music_folder` key.
+    *   Set its value to the absolute path of your desired music folder. For example:
+        ```toml
+        background_music_folder = "/home/pi/my_music_collection"
+        ```
+    *   Ensure this folder exists and contains your audio files.
+
+If neither a custom folder is specified and valid, nor the default `bgmusic` folder exists or contains music, no background music will be played.
+
+The script will play all supported audio files from the chosen folder in a loop.
 
 ## Setup the Service
 


### PR DESCRIPTION
This commit introduces the ability for users to specify a folder for background music tracks, moving away from a hardcoded list of files.

Key changes:
- Added `load_audio_files` function to `play_audio.py` to scan a directory for .mp3 and .wav files.
- Modified `play_audio.py` to:
  - Read a `background_music_folder` path from `config.toml`.
  - If not specified or invalid, fall back to a default `bgmusic` folder in the working directory (e.g., `~/Radio/bgmusic/`).
  - If neither a configured path nor the default folder yields music files, no background music will be played, and warnings will be logged.
  - The hardcoded `AUDIO_FILES` list has been removed.
  - Config reloading logic now also reloads music files from the appropriate folder.
- Added `background_music_folder` option to `config.toml` with explanatory comments.
- Created an empty `bgmusic` directory as the default location.
- Updated `readme.md` to explain the new background music configuration options.